### PR TITLE
Foreground colors in labels no longer ignored in Ubuntu

### DIFF
--- a/bingada.css
+++ b/bingada.css
@@ -2,7 +2,8 @@ GtkButton {
     background-image: none;
 }
 
-#myButton_white{
+#myButton_white,
+#myButton_white > label {
     background-color: white;
     color: red;
     font-family: DejaVu Sans;
@@ -12,7 +13,8 @@ GtkButton {
     border-radius: 0px;
 }
 
-#myButton_blue{
+#myButton_blue,
+#myButton_blue > label {
     background-color: blue;
     color: white;
     font-family: DejaVu Sans;
@@ -21,7 +23,8 @@ GtkButton {
     font-size: xx-large;
 }
 
-#myButton_previous_1{
+#myButton_previous_1,
+#myButton_previous_1 > label {
     background-color: lightgreen;
     color: black;
     font-family: DejaVu Sans;
@@ -31,7 +34,8 @@ GtkButton {
     border-radius: 10px;
 }
 
-#myButton_previous_2{
+#myButton_previous_2,
+#myButton_previous_2 > label {
     background-color: lightblue;
     color: black;
     font-family: DejaVu Sans;
@@ -41,7 +45,8 @@ GtkButton {
     border-radius: 10px;
 }
 
-#myButton_previous_3{
+#myButton_previous_3,
+#myButton_previous_3 > label {
     background-color: grey;
     color: black;
     font-family: DejaVu Sans;
@@ -57,3 +62,6 @@ GtkButton {
    color: blue;
 }
 
+#drum_button {
+     background-color: white;
+}

--- a/src/q_bingada.adb
+++ b/src/q_bingada.adb
@@ -515,6 +515,8 @@ package body Q_BINGADA is
     
     V_BOMBO_BUTTON.SET_IMAGE (IMAGE => V_BOMBO_IMAGE);
 
+    V_BOMBO_BUTTON.Set_Name ("drum_button");
+
     GTK.BOX.PACK_START
        (IN_BOX => V_UPPER_AREA,
         CHILD  => V_BOMBO_BUTTON);


### PR DESCRIPTION
It seems that in this environment, the style has to be explicity applied
to the labels inside the buttons.

The background of the image button has also ben set so it is white,like
the image itself.

This fixes issue #5